### PR TITLE
Remove unused json_web_token dependency

### DIFF
--- a/intuit-oauth.gemspec
+++ b/intuit-oauth.gemspec
@@ -6,7 +6,6 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.add_dependency 'httparty', '~> 0.16.3'
   spec.add_dependency 'json', '~> 2.1'
-  spec.add_dependency 'json_web_token', '~> 0.3.5'
   spec.add_dependency 'rsa-pem-from-mod-exp', '~> 0.1.0'
 
   spec.authors       = ['Intuit Inc']

--- a/lib/intuit-oauth/flow/openid.rb
+++ b/lib/intuit-oauth/flow/openid.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 require 'rsa_pem'
-require 'json_web_token'
 
 require_relative '../base'
 


### PR DESCRIPTION
Fix to issue #2 
Removes json_web_token gem as dependency as it is not currently used.