### PR TITLE
Relax version requirement for `json` dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
     httparty (0.17.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    json (1.8.6)
+    json (2.1.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
     httparty (0.17.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    json (2.1.0)
+    json (1.8.6)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)

--- a/intuit-oauth.gemspec
+++ b/intuit-oauth.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'httparty', '>= 0.16.3'
-  spec.add_dependency 'json', '~> 2.1'
+  spec.add_dependency 'json', '>= 1.8.6'
   spec.add_dependency 'rsa-pem-from-mod-exp', '~> 0.1.0'
 
   spec.authors       = ['Intuit Inc']

--- a/intuit-oauth.gemspec
+++ b/intuit-oauth.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'httparty', '>= 0.16.3'
-  spec.add_dependency 'json', '>= 1.8.6'
+  spec.add_dependency 'json', '>= 1.8.0'
   spec.add_dependency 'rsa-pem-from-mod-exp', '~> 0.1.0'
 
   spec.authors       = ['Intuit Inc']


### PR DESCRIPTION
## Purpose

Given that there's not necessarily a need for any functionality in later versions of this gem, it makes sense to relax the dependency to avoid conflicting with other gem versions consumers might be dependent on.

We might be able to go as low as `json (>=1.6.7)` here, but I don't think any lower than that is possible, due to changes to the `JSON.parse` function losing a null check.

Addresses #9 