### PR TITLE
Use HTTParty class methods brought in by include.

### DIFF
--- a/lib/intuit-oauth/transport.rb
+++ b/lib/intuit-oauth/transport.rb
@@ -31,12 +31,12 @@ module IntuitOAuth
       req_headers = headers.nil? ? user_agent_header : user_agent_header.merge!(headers)
 
       if method == 'GET'
-        response = HTTParty.get(url,
+        response = get(url,
           headers: req_headers
         )
 
       elsif method == 'POST'
-        response = HTTParty.post(url,
+        response = post(url,
           headers: req_headers,
           body: body
         )


### PR DESCRIPTION
When you call `include HTTParty`, class methods such as `get` and `post` are defined. This PR makes a change to `IntuitOAuth::Transport` to call the class methods.

The advantage of this approach is that [`connection_adapter`](https://github.com/jnunemaker/httparty/blob/d2ff83b5af9cded96903c38a242e2e8c31d2bf6a/lib/httparty.rb#L471-L493) and other configuration methods will work on `IntuitOAuth::Transport`.