### PR TITLE
Make exception instance variables accessible with attr_reader

### DIFF
--- a/lib/intuit-oauth/exception.rb
+++ b/lib/intuit-oauth/exception.rb
@@ -1,12 +1,14 @@
 module IntuitOAuth
   class OAuth2ClientException < StandardError
+    attr_reader :status_code, :body, :headers, :intuit_tid, :timestamp
+
     def initialize(response)
-      @satus_code = response.code
+      @status_code = response.code
       @body = response.body
       @headers = response.headers
       @intuit_tid = response.headers['intuit_tid']
       @timestamp = response.headers['date']
-      super("HTTP status #{@satus_code}, error message: #{@body}, intuit_tid: #{@intuit_tid} on #{@timestamp}")
+      super("HTTP status #{@status_code}, error message: #{@body}, intuit_tid: #{@intuit_tid} on #{@timestamp}")
     end
   end
 end


### PR DESCRIPTION
### Purpose 
This PR makes the instance variables in `OAuth2ClientException` accessible with `attr_reader`. This change will allow clients to cleanly inspect errors when they occur instead of having to parse the error message, i.e. 
```
rescue OAuth2ClientException => e 
  if e.status_code == 401
    ... 
  elsif e.status_code == 500
    ...
  else
    ...
  end 
```

This PR also fixes a typo: `satus_code` -> `status_code`. Since the instance variable isn't currently accessible outside of this class, this fix should only be backwards incompatible if an existing client is using `e.instance_variable_get(:@satus_code)`. 
